### PR TITLE
docs: update branch deletion command to use force flag

### DIFF
--- a/.github/instructions/dev-flow.instructions.md
+++ b/.github/instructions/dev-flow.instructions.md
@@ -182,7 +182,7 @@ Commit → Push → Review → Adjustments → Commit → Push → Approval
 
 **Command (after merge):**
 ```bash
-git branch -d branch-name
+git branch -D branch-name
 git push origin --delete branch-name
 ```
 

--- a/.github/prompts/up.prompt.md
+++ b/.github/prompts/up.prompt.md
@@ -1,0 +1,11 @@
+---
+agent: agent
+tools: ['runCommands', 'github/*', 'changes']
+---
+
+YOU MUST FOLLOW THE PROJECT'S GUIDELINES/INSTRUCTIONS.
+YOU MUST CHECK IF THERE IS AN OPEN ISSUE FOR THE CHANGES YOU ARE MAKING. IF NOT, CREATE ONE FIRST.
+YOU MUST CHECK IF THERE IS ALREADY AN OPEN PULL REQUEST FOR THE SAME ISSUE BEFORE CREATING A NEW ONE.
+Understand the changes, commit what's necessary, and create a concise pull request description summarizing the changes made.
+Remember: every pull request must have a previous issue created for it.
+Remember: if you are on the `master` branch, you must create a new branch for your changes. NEVER commit directly to `master`.


### PR DESCRIPTION
## Summary

Updates the branch deletion command in the dev-flow instructions and adds an automated PR workflow prompt.

## Changes

- Changed `git branch -d` to `git branch -D` in `.github/instructions/dev-flow.instructions.md`
- Added `.github/prompts/up.prompt.md` for automated PR creation workflow

## Motivation

The `-D` flag (force delete) is more reliable than `-d` in our workflow because:
- It works even after rebase/squash merges where Git may not recognize the branch as fully merged
- Prevents issues when trying to delete branches that have been rebased
- Aligns with the workflow's preference for rebase over merge commits

The `up.prompt.md` file provides instructions for automated PR creation, ensuring consistency in the PR workflow.

## Related Issue

Closes #8